### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Docker client to run selenium JS scripts against a running selenium/standalone-c
 or   
 
 ```
-docker run -d -P --name chrome selenium/hub:2.45.0
+docker run -d -P --name selenium-hub selenium/hub:2.45.0
 docker run  --privileged -d -P --name chrome --link selenium-hub:hub selenium/node-chrome-debug:2.45.0`
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Docker client to run selenium JS scripts against a running selenium/standalone-c
 
 ### 1. First start an instance of standalone-chrome or a chrome node with a hub   
 
-`docker run -d -P --name selenium-hub selenium/hub:2.45.0`   
+`docker run -d -P --name selenium-hub selenium/standalone-chrome:2.45.0`
 
 or   
 
 ```
 docker run -d -P --name selenium-hub selenium/hub:2.45.0
-docker run  --privileged -d -P --name chrome --link selenium-hub:hub selenium/node-chrome-debug:2.45.0`
+docker run  --privileged -d -P --name chrome --link selenium-hub:hub selenium/node-chrome-debug:2.45.0
 ```
 
 If you use this debug image you can connect to the browser using vnc, on a Mac you can do this by entering `vnc://[cid for node-chrome-debug container]:5900`   


### PR DESCRIPTION
I changed the name of the selenium hub docker container.  It was being named "chrome" which didn't really make sense.

I also changed the first line of code to reflect the description rather than just starting a hub with no nodes, it now starts a standalone chrome container.
